### PR TITLE
Remove utf8_encode()

### DIFF
--- a/src/EmailFactory.php
+++ b/src/EmailFactory.php
@@ -29,8 +29,8 @@ class EmailFactory
         // Parse the message body
         $parser = new Parser();
         $parser->setText($hordeEmail->getFullMsg());
-        $htmlContent = utf8_encode((string) $parser->getMessageBody('html'));
-        $textContent = utf8_encode((string) $parser->getMessageBody('text'));
+        $htmlContent = (string) $parser->getMessageBody('html');
+        $textContent = (string) $parser->getMessageBody('text');
 
         // Filter HTML body to have only safe HTML
         $htmlContent = trim($this->htmlFilter->purify($htmlContent));


### PR DESCRIPTION
This definitely shouldn't be here, and I'm fairly certain is the root cause of https://github.com/mnapoli/externals/issues/11 - the example linked there is a classic UTF-8 double-encoding issue.

The character set of the message is [decoded on retrieval](https://github.com/php-mime-mail-parser/php-mime-mail-parser/blob/2.8.0/src/Parser.php#L338), since no decoder is passed to the parser explicitly [the default is used](https://github.com/php-mime-mail-parser/php-mime-mail-parser/blob/2.8.0/src/Parser.php#L62-L64), the default decoder always [returns valid UTF-8](https://github.com/php-mime-mail-parser/php-mime-mail-parser/blob/2.8.0/src/Charset.php#L316-L323).

Also ftr `utf8_encode()` and `utf8_decode()` are almost completely useless (they *only* make sense when the other relevant charset is ISO-8859-1) and should probably be deprecated in PHP.