### PR TITLE
Explicitly define flags property

### DIFF
--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -20,6 +20,11 @@ class Query
      */
     private $youngerThan;
 
+    /**
+     * @var array
+     */
+    private $flags = [];
+
     public function getFolder() : string
     {
         return $this->folder;


### PR DESCRIPTION
By explicitly defining the `flags` class property and setting it to an empty array we can prevent errors when not using the flags feature.

Prior to this change the lack of using flags (i.e. not setting any flags) would cause an error since the Client code ALWAYS calls `$this->setFlags`, which in turn always calls `$query->getFlags()`.

Fixes bug introduced in #6 and reported in #9.